### PR TITLE
Remove dots in the middle of files path

### DIFF
--- a/scripts/quick_start/quick_start_demo.py
+++ b/scripts/quick_start/quick_start_demo.py
@@ -161,10 +161,10 @@ ec = 0
 eList = errorList()
 server_devices = []
 
-soft_dev_hex52    =  cwd + "./bin/softdevice/s132_nrf52_6.0.0_softdevice.hex"
-provisioner_hex52 =  cwd + "./bin/otime/light_switch_provisioner_nrf52832_xxAA_s132_6.0.0.hex"
-client_hex52      =  cwd + "./bin/otime/light_switch_client_nrf52832_xxAA_s132_6.0.0.hex"
-server_hex52      =  cwd + "./bin/otime/light_switch_server_nrf52832_xxAA_s132_6.0.0.hex"
+soft_dev_hex52    =  cwd + "/bin/softdevice/s132_nrf52_6.0.0_softdevice.hex"
+provisioner_hex52 =  cwd + "/bin/otime/light_switch_provisioner_nrf52832_xxAA_s132_6.0.0.hex"
+client_hex52      =  cwd + "/bin/otime/light_switch_client_nrf52832_xxAA_s132_6.0.0.hex"
+server_hex52      =  cwd + "/bin/otime/light_switch_server_nrf52832_xxAA_s132_6.0.0.hex"
 
 # All files must be valid
 for f in [soft_dev_hex52, provisioner_hex52, client_hex52, server_hex52]:


### PR DESCRIPTION
Hi,

Description: Remove dots in the middle of files path used in the quickstart python script.

Problem: When I tried to run for the first time ``quick_start_demo.py``, I got the following error:

``
$ python scripts/quick_start/quick_start_demo.py
Current directory: /home/boinc/Documents/nordic-dev/nrf_mesh_sdk_git
Error: File  /home/boinc/Documents/nordic-dev/nrf_mesh_sdk_git./bin/softdevice/s132_nrf52_6.0.0_softdevice.hex  does not exist
``

After the fix the script run normally.