### PR TITLE
Removed redundant assignment of state variable m_prov_state

### DIFF
--- a/examples/light_switch/provisioner/src/provisioner_helper.c
+++ b/examples/light_switch/provisioner/src/provisioner_helper.c
@@ -112,7 +112,6 @@ static void start_provisioning(const uint8_t * p_uuid)
         };
     memcpy(prov_data.netkey, m_provisioner.p_nw_data->netkey, NRF_MESH_KEY_SIZE);
     ERROR_CHECK(nrf_mesh_prov_provision(&m_prov_ctx, p_uuid, &prov_data, NRF_MESH_PROV_BEARER_ADV));
-    m_prov_state = PROV_STATE_PROV;
 }
 
 static void prov_helper_provisioner_init(void)


### PR DESCRIPTION
The variable is assigned at line #150 after start_provisioning is called.