### PR TITLE
Fix logging

### DIFF
--- a/CMake/sdk/nRF5_SDK_15.2.0_9412b96.cmake
+++ b/CMake/sdk/nRF5_SDK_15.2.0_9412b96.cmake
@@ -4,6 +4,7 @@ set(nRF5_SDK_15.2.0_9412b96_SOURCE_FILES
 
 set(nRF5_SDK_15.2.0_9412b96_INCLUDE_DIRS
     "${SDK_ROOT}/integration/nrfx"
+    "${SDK_ROOT}/components/libraries/memobj"
     "${SDK_ROOT}/components/libraries/util"
     "${SDK_ROOT}/components/libraries/timer"
     "${SDK_ROOT}/components/libraries/log"

--- a/CMake/sdk/nRF5_SDK_15.2.0_9412b96.cmake
+++ b/CMake/sdk/nRF5_SDK_15.2.0_9412b96.cmake
@@ -1,11 +1,24 @@
+set(DEPENDENCIES_LOGGING_SOURCE_FILES
+    "${SDK_ROOT}/components/libraries/balloc/nrf_balloc.c"
+    "${SDK_ROOT}/components/libraries/memobj/nrf_memobj.c"
+    "${SDK_ROOT}/components/libraries/log/src/nrf_log_frontend.c"
+    "${SDK_ROOT}/components/libraries/strerror/nrf_strerror.c"
+)
+
+set(DEPENDENCIES_LOGGING_INCLUDE_DIRS
+    "${SDK_ROOT}/external/fprintf"
+    "${SDK_ROOT}/components/libraries/balloc"
+    "${SDK_ROOT}/components/libraries/ringbuf"
+    "${SDK_ROOT}/components/libraries/memobj")
+
 set(nRF5_SDK_15.2.0_9412b96_SOURCE_FILES
+    ${DEPENDENCIES_LOGGING_SOURCE_FILES}
     "${SDK_ROOT}/components/libraries/util/app_error.c"
     "${SDK_ROOT}/components/libraries/util/app_util_platform.c")
 
 set(nRF5_SDK_15.2.0_9412b96_INCLUDE_DIRS
+    ${DEPENDENCIES_LOGGING_INCLUDE_DIRS}
     "${SDK_ROOT}/integration/nrfx"
-    "${SDK_ROOT}/components/libraries/balloc"
-    "${SDK_ROOT}/components/libraries/memobj"
     "${SDK_ROOT}/components/libraries/util"
     "${SDK_ROOT}/components/libraries/timer"
     "${SDK_ROOT}/components/libraries/log"

--- a/CMake/sdk/nRF5_SDK_15.2.0_9412b96.cmake
+++ b/CMake/sdk/nRF5_SDK_15.2.0_9412b96.cmake
@@ -4,6 +4,7 @@ set(nRF5_SDK_15.2.0_9412b96_SOURCE_FILES
 
 set(nRF5_SDK_15.2.0_9412b96_INCLUDE_DIRS
     "${SDK_ROOT}/integration/nrfx"
+    "${SDK_ROOT}/components/libraries/balloc"
     "${SDK_ROOT}/components/libraries/memobj"
     "${SDK_ROOT}/components/libraries/util"
     "${SDK_ROOT}/components/libraries/timer"


### PR DESCRIPTION
Added libraries (source) and includes to fix `cmake`d builds that have `NRF_LOG_ENABLED` set to 1.
Now, logging works.

Fixes in detail:

```
In file included from /something/nRF5SDK/components/libraries/log/nrf_log_ctrl.h:59,
                 from /something/nRF5SDK/components/ble/peer_manager/gatt_cache_manager.c:64:
/something/nRF5SDK/components/libraries/log/nrf_log_backend_interface.h:54:10: fatal error: nrf_memobj.h: No such file or directory
 #include "nrf_memobj.h"
```

and it's recursive dependencies (balloc, strfmt, ...)